### PR TITLE
fix: implement scrolling for sessions and projects views

### DIFF
--- a/internal/tui/views/projects.go
+++ b/internal/tui/views/projects.go
@@ -134,7 +134,32 @@ func (v *ProjectsView) View(width, height int) string {
 	b.WriteString(header + "\n")
 	b.WriteString("  " + strings.Repeat("\u2500", 82) + "\n")
 
-	for i, row := range rows {
+	// Calculate scrolling window
+	maxRows := height - 5 // header + separator + padding
+	if maxRows < 1 {
+		maxRows = 1
+	}
+
+	start := 0
+	end := len(rows)
+
+	if len(rows) > maxRows {
+		// Keep selected item in view with some context
+		if v.selected >= maxRows {
+			start = v.selected - maxRows + 1
+		}
+		end = start + maxRows
+		if end > len(rows) {
+			end = len(rows)
+			start = end - maxRows
+			if start < 0 {
+				start = 0
+			}
+		}
+	}
+
+	for i := start; i < end; i++ {
+		row := rows[i]
 		name := row.Name
 		if len(name) > 50 {
 			name = "..." + name[len(name)-47:]

--- a/internal/tui/views/projects_test.go
+++ b/internal/tui/views/projects_test.go
@@ -1,6 +1,7 @@
 package views
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -163,5 +164,169 @@ func TestProjectsView_Empty(t *testing.T) {
 
 	if content == "" {
 		t.Error("expected non-empty view even when empty")
+	}
+}
+
+// TestProjectsView_Scrolling verifies that when there are more projects than can fit
+// on screen, the view implements a scrolling window that follows the selected item.
+func TestProjectsView_Scrolling(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	// Add 50 projects to test scrolling
+	for i := range 50 {
+		projectPath := fmt.Sprintf("project-%d", i)
+		s.Add(&model.SessionMeta{
+			UUID:         fmt.Sprintf("u%d", i),
+			Slug:         fmt.Sprintf("session-%d", i),
+			ProjectPath:  projectPath,
+			StartTime:    now.Add(time.Duration(i) * time.Hour),
+			Models:       map[string]int{},
+			ToolUsage:    map[string]int{},
+			SkillsUsed:   map[string]int{},
+			CommandsUsed: map[string]int{},
+			FileOps:      map[string]int{},
+		})
+	}
+
+	view := NewProjectsView(s)
+	// Small height to force scrolling (only 5 visible rows)
+	content := view.View(100, 10)
+
+	// Count visible project rows
+	lines := strings.Split(content, "\n")
+	dataLines := 0
+	for _, line := range lines {
+		if strings.Contains(line, ">") || (strings.HasPrefix(line, "  ") && len(strings.TrimSpace(line)) > 0 && !strings.Contains(line, "Project") && !strings.Contains(line, "\u2500")) {
+			dataLines++
+		}
+	}
+
+	if dataLines > 5 {
+		t.Errorf("expected at most 5 visible rows, got %d", dataLines)
+	}
+
+	// Navigate down 10 times
+	for range 10 {
+		view.Update(tea.KeyMsg{Type: tea.KeyDown})
+	}
+
+	// Should now show projects around index 10
+	content = view.View(100, 10)
+
+	// The selected project should be visible
+	view.View(100, 10) // Refresh lastRows
+	selectedPath := view.SelectedProject()
+	if selectedPath == "" {
+		t.Fatal("expected non-empty selected project")
+	}
+
+	// Decode the project path for display
+	decoded := "/" + strings.ReplaceAll(strings.TrimPrefix(selectedPath, "-"), "-", "/")
+	if !strings.Contains(content, decoded) {
+		t.Errorf("expected selected project to be visible after scrolling")
+	}
+}
+
+// TestProjectsView_ScrollingVimKeys verifies that vim-style j/k keys work for
+// scrolling through projects and that the selected item remains visible.
+func TestProjectsView_ScrollingVimKeys(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	// Add 30 projects
+	for i := range 30 {
+		projectPath := fmt.Sprintf("project-%d", i)
+		s.Add(&model.SessionMeta{
+			UUID:         fmt.Sprintf("u%d", i),
+			Slug:         fmt.Sprintf("session-%d", i),
+			ProjectPath:  projectPath,
+			StartTime:    now.Add(time.Duration(i) * time.Hour),
+			Models:       map[string]int{},
+			ToolUsage:    map[string]int{},
+			SkillsUsed:   map[string]int{},
+			CommandsUsed: map[string]int{},
+			FileOps:      map[string]int{},
+		})
+	}
+
+	view := NewProjectsView(s)
+
+	// Navigate down with 'j' key
+	for range 15 {
+		view.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	}
+
+	if view.selected != 15 {
+		t.Errorf("expected selected=15 after 15 'j' presses, got %d", view.selected)
+	}
+
+	// Navigate up with 'k' key
+	for range 5 {
+		view.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	}
+
+	if view.selected != 10 {
+		t.Errorf("expected selected=10 after 5 'k' presses, got %d", view.selected)
+	}
+
+	// Verify selected project is visible
+	content := view.View(100, 10)
+	selectedPath := view.SelectedProject()
+	decoded := "/" + strings.ReplaceAll(strings.TrimPrefix(selectedPath, "-"), "-", "/")
+	if !strings.Contains(content, decoded) {
+		t.Errorf("expected selected project to be visible after vim key navigation")
+	}
+}
+
+// TestProjectsView_ScrollingBounds verifies that scrolling is properly bounded
+// at the top and bottom of the list, and that the selected item is always visible.
+func TestProjectsView_ScrollingBounds(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	// Add 20 projects
+	for i := range 20 {
+		projectPath := fmt.Sprintf("project-%d", i)
+		s.Add(&model.SessionMeta{
+			UUID:         fmt.Sprintf("u%d", i),
+			Slug:         fmt.Sprintf("session-%d", i),
+			ProjectPath:  projectPath,
+			StartTime:    now.Add(time.Duration(i) * time.Hour),
+			Models:       map[string]int{},
+			ToolUsage:    map[string]int{},
+			SkillsUsed:   map[string]int{},
+			CommandsUsed: map[string]int{},
+			FileOps:      map[string]int{},
+		})
+	}
+
+	view := NewProjectsView(s)
+
+	// Try to scroll up from the top
+	view.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if view.selected != 0 {
+		t.Errorf("expected selected=0 when scrolling up from top, got %d", view.selected)
+	}
+
+	// Scroll to bottom
+	for range 25 {
+		view.Update(tea.KeyMsg{Type: tea.KeyDown})
+	}
+
+	// Render to populate lastRows and clamp selection
+	view.View(100, 10)
+
+	// Should be clamped to last item (19)
+	if view.selected != 19 {
+		t.Errorf("expected selected=19 at bottom, got %d", view.selected)
+	}
+
+	// Verify last project is visible
+	content := view.View(100, 10)
+	selectedPath := view.SelectedProject()
+	decoded := "/" + strings.ReplaceAll(strings.TrimPrefix(selectedPath, "-"), "-", "/")
+	if !strings.Contains(content, decoded) {
+		t.Errorf("expected last project to be visible when scrolled to bottom")
 	}
 }

--- a/internal/tui/views/sessions.go
+++ b/internal/tui/views/sessions.go
@@ -129,10 +129,27 @@ func (v *SessionsView) View(width, height int) string {
 		maxRows = 1
 	}
 
-	for i, row := range v.rows {
-		if i >= maxRows {
-			break
+	// Calculate scrolling window
+	start := 0
+	end := len(v.rows)
+
+	if len(v.rows) > maxRows {
+		// Keep selected item in view with some context
+		if v.selected >= maxRows {
+			start = v.selected - maxRows + 1
 		}
+		end = start + maxRows
+		if end > len(v.rows) {
+			end = len(v.rows)
+			start = end - maxRows
+			if start < 0 {
+				start = 0
+			}
+		}
+	}
+
+	for i := start; i < end; i++ {
+		row := v.rows[i]
 
 		slug := row.Slug
 		if slug == "" {

--- a/internal/tui/views/sessions_test.go
+++ b/internal/tui/views/sessions_test.go
@@ -1,6 +1,7 @@
 package views
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -251,5 +252,157 @@ func TestVisibleSessions(t *testing.T) {
 	// Should be sorted newest first
 	if rows[0].Slug != "beta" {
 		t.Errorf("expected first visible session 'beta', got %q", rows[0].Slug)
+	}
+}
+
+// TestSessionsView_Scrolling verifies that when there are more sessions than can fit
+// on screen, the view implements a scrolling window that follows the selected item.
+func TestSessionsView_Scrolling(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	// Add 50 sessions to test scrolling
+	for i := range 50 {
+		s.Add(&model.SessionMeta{
+			UUID:         fmt.Sprintf("u%d", i),
+			Slug:         fmt.Sprintf("session-%d", i),
+			ProjectPath:  "-p",
+			StartTime:    now.Add(time.Duration(i) * time.Hour),
+			Models:       map[string]int{},
+			ToolUsage:    map[string]int{},
+			SkillsUsed:   map[string]int{},
+			CommandsUsed: map[string]int{},
+			FileOps:      map[string]int{},
+		})
+	}
+
+	view := NewSessionsView(s)
+	// Small height to force scrolling (only 5 visible rows)
+	content := view.View(100, 10)
+
+	// Should show first 5 sessions (newest first)
+	lines := strings.Split(content, "\n")
+	dataLines := 0
+	for _, line := range lines {
+		if strings.Contains(line, ">") || (strings.HasPrefix(line, "  ") && len(strings.TrimSpace(line)) > 0 && !strings.Contains(line, "Slug") && !strings.Contains(line, "\u2500")) {
+			dataLines++
+		}
+	}
+
+	if dataLines > 5 {
+		t.Errorf("expected at most 5 visible rows, got %d", dataLines)
+	}
+
+	// Navigate down 10 times
+	for range 10 {
+		view.Update(tea.KeyMsg{Type: tea.KeyDown})
+	}
+
+	// Should now show sessions around index 10
+	content = view.View(100, 10)
+
+	// The selected session should be visible
+	selected := view.SelectedSession()
+	if selected == nil {
+		t.Fatal("expected non-nil selected session")
+	}
+	if !strings.Contains(content, selected.Slug) {
+		t.Errorf("expected selected session %q to be visible after scrolling", selected.Slug)
+	}
+}
+
+// TestSessionsView_ScrollingVimKeys verifies that vim-style j/k keys work for
+// scrolling through sessions and that the selected item remains visible.
+func TestSessionsView_ScrollingVimKeys(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	// Add 30 sessions
+	for i := range 30 {
+		s.Add(&model.SessionMeta{
+			UUID:         fmt.Sprintf("u%d", i),
+			Slug:         fmt.Sprintf("session-%d", i),
+			ProjectPath:  "-p",
+			StartTime:    now.Add(time.Duration(i) * time.Hour),
+			Models:       map[string]int{},
+			ToolUsage:    map[string]int{},
+			SkillsUsed:   map[string]int{},
+			CommandsUsed: map[string]int{},
+			FileOps:      map[string]int{},
+		})
+	}
+
+	view := NewSessionsView(s)
+
+	// Navigate down with 'j' key
+	for range 15 {
+		view.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	}
+
+	if view.selected != 15 {
+		t.Errorf("expected selected=15 after 15 'j' presses, got %d", view.selected)
+	}
+
+	// Navigate up with 'k' key
+	for range 5 {
+		view.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	}
+
+	if view.selected != 10 {
+		t.Errorf("expected selected=10 after 5 'k' presses, got %d", view.selected)
+	}
+
+	// Verify selected session is visible
+	content := view.View(100, 10)
+	selected := view.SelectedSession()
+	if !strings.Contains(content, selected.Slug) {
+		t.Errorf("expected selected session to be visible after vim key navigation")
+	}
+}
+
+// TestSessionsView_ScrollingBounds verifies that scrolling is properly bounded
+// at the top and bottom of the list, and that the selected item is always visible.
+func TestSessionsView_ScrollingBounds(t *testing.T) {
+	s := store.New()
+	now := time.Now()
+
+	// Add 20 sessions
+	for i := range 20 {
+		s.Add(&model.SessionMeta{
+			UUID:         fmt.Sprintf("u%d", i),
+			Slug:         fmt.Sprintf("session-%d", i),
+			ProjectPath:  "-p",
+			StartTime:    now.Add(time.Duration(i) * time.Hour),
+			Models:       map[string]int{},
+			ToolUsage:    map[string]int{},
+			SkillsUsed:   map[string]int{},
+			CommandsUsed: map[string]int{},
+			FileOps:      map[string]int{},
+		})
+	}
+
+	view := NewSessionsView(s)
+
+	// Try to scroll up from the top
+	view.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if view.selected != 0 {
+		t.Errorf("expected selected=0 when scrolling up from top, got %d", view.selected)
+	}
+
+	// Scroll to bottom
+	for range 25 {
+		view.Update(tea.KeyMsg{Type: tea.KeyDown})
+	}
+
+	// Should be clamped to last item (19)
+	if view.selected != 19 {
+		t.Errorf("expected selected=19 at bottom, got %d", view.selected)
+	}
+
+	// Verify last session is visible
+	content := view.View(100, 10)
+	selected := view.SelectedSession()
+	if !strings.Contains(content, selected.Slug) {
+		t.Errorf("expected last session to be visible when scrolled to bottom")
 	}
 }


### PR DESCRIPTION
## Problem

When there are more sessions or projects than can fit on the current screen, the list gets cut off and users can't navigate to items beyond the visible area. The selected item may also move off-screen when navigating.

## Solution

Implement a scrolling window mechanism that:
- Calculates which rows should be visible based on the selected item
- Keeps the selected item in view as the user navigates with arrow keys or vim keys (j/k)
- Properly handles bounds at the top and bottom of the list

## Testing

Added tests for:
- Scrolling with arrow keys
- Vim-style navigation (j/k keys)
- Bounds checking at top and bottom
